### PR TITLE
Draft: is_http

### DIFF
--- a/mirrord/http/Cargo.toml
+++ b/mirrord/http/Cargo.toml
@@ -18,6 +18,7 @@ edition.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 mirrord-protocol = { path = "../protocol" }
+futures.workspace = true
 
 hyper = { version = "1.0.0-rc.1", features = ["full"] }
 tokio = { version = "*", features = ["full"] }

--- a/mirrord/http/src/lib.rs
+++ b/mirrord/http/src/lib.rs
@@ -3,15 +3,19 @@
 #![warn(rustdoc::missing_crate_level_docs)]
 
 use core::convert::Infallible;
+use std::{thread::sleep, time::Duration};
 
 use fancy_regex::Regex;
+use futures::future::poll_fn;
 use hyper::{body, server::conn::http1, service::service_fn, Request, Response};
 use mirrord_protocol::tcp::RegexFilter;
 use thiserror::Error;
 use tokio::{
-    io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream},
+    io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream, ReadBuf},
+    net::TcpStream,
     sync::mpsc::{channel, Receiver, Sender},
 };
+use tracing::debug;
 
 static SELECT_ALL: &str = ".*";
 
@@ -131,6 +135,47 @@ impl HttpProxy {
 
         todo!()
     }
+}
+
+const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0";
+
+/// Should we treat `tcp_stream` as http?
+///
+/// Does not consume bytes from the stream.
+/// This is a best effort classification, not a guarantee that the request is well-formed and valid.
+/// For HTTP 1 it is verified that the start of the stream is
+/// ```text
+/// METHOD PREFIX-OF-TARGET
+/// ```
+/// or
+/// ```text
+/// METHOD TARGET PREFIX-OF-HTTP-VERSION
+/// ```
+/// And that all present parts are valid.
+/// For HTTP 2 the preface is verified.
+pub async fn is_http(tcp_stream: TcpStream) -> bool {
+    let mut buf = [0u8; 64];
+    let mut buf = ReadBuf::new(&mut buf);
+
+    let mut empty_headers = [httparse::EMPTY_HEADER; 0];
+
+    // Keep peeking until we have enough bytes to decide.
+    while let Ok(num_bytes) = poll_fn(|cx| tcp_stream.poll_peek(cx, &mut buf)).await? {
+        if num_bytes >= H2_PREFACE.le() {
+            return buf[1..H2_PREFACE.len()] == H2_PREFACE
+                || matches!(
+                    httparse::Request::new(&mut empty_headers).parse(&buf[..]),
+                    Ok(_) | Err(httparse::Error::TooManyHeaders)
+                );
+        }
+        if num_bytes == 0 {
+            debug!("Stream closed without data.");
+            return false;
+        }
+        // Make the waiting less busy.
+        sleep(Duration::from_micros(100)); // TODO: how much should we sleep?
+    }
+    false
 }
 
 const MINIMAL_HTTP1_REQUEST: &str = "GET / HTTP/1.1";

--- a/mirrord/http/src/lib.rs
+++ b/mirrord/http/src/lib.rs
@@ -161,7 +161,7 @@ pub async fn is_http(tcp_stream: TcpStream) -> bool {
 
     // Keep peeking until we have enough bytes to decide.
     while let Ok(num_bytes) = poll_fn(|cx| tcp_stream.poll_peek(cx, &mut buf)).await? {
-        if num_bytes >= H2_PREFACE.le() {
+        if num_bytes >= H2_PREFACE.len() {
             return buf[1..H2_PREFACE.len()] == H2_PREFACE
                 || matches!(
                     httparse::Request::new(&mut empty_headers).parse(&buf[..]),


### PR DESCRIPTION
This implementation is pretty ugly, with busy waiting for more bytes in the (unlikely?) event that the first peek does not supply enough bytes.

In order to eliminate this busy waiting we could either:
1. Just verify as much bytes as we get in the first poll without looping, under the assumption we will probably always get enough, and even if we get less bytes, if the first couple of bytes that's probably fine.
2. Implement a stream that does consume bytes from the TcpStream, but buffers them so that all bytes, including the one already consumed can then be read by other consumers. 

I tend towards option 1, bet let me know what you think.