### PR TITLE
Send a `RemoteResult` in the `Subscribed` message.

### DIFF
--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -352,7 +352,7 @@ impl TcpConnectionSniffer {
     ) -> Result<(), AgentError> {
         self.port_subscriptions.subscribe(client_id, port);
         self.update_sniffer()?;
-        self.send_message_to_client(&client_id, DaemonTcp::Subscribed)
+        self.send_message_to_client(&client_id, DaemonTcp::Subscribed(Ok(port)))
             .await
     }
 

--- a/mirrord/agent/src/sniffer.rs
+++ b/mirrord/agent/src/sniffer.rs
@@ -352,7 +352,7 @@ impl TcpConnectionSniffer {
     ) -> Result<(), AgentError> {
         self.port_subscriptions.subscribe(client_id, port);
         self.update_sniffer()?;
-        self.send_message_to_client(&client_id, DaemonTcp::Subscribed(Ok(port)))
+        self.send_message_to_client(&client_id, DaemonTcp::SubscribeResult(Ok(port)))
             .await
     }
 

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -248,7 +248,7 @@ impl TcpConnectionStealer {
                     .add_redirect(port, self.stealer.local_addr()?.port())?;
                 Ok(port)
             };
-        self.send_message_to_single_client(&client_id, DaemonTcp::Subscribed(res))
+        self.send_message_to_single_client(&client_id, DaemonTcp::SubscribeResult(res))
             .await
     }
 

--- a/mirrord/agent/src/steal/connection.rs
+++ b/mirrord/agent/src/steal/connection.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use bytes::Bytes;
-use mirrord_protocol::tcp::{NewTcpConnection, TcpClose};
+use mirrord_protocol::{
+    tcp::{NewTcpConnection, TcpClose},
+    ResponseError::PortAlreadyStolen,
+};
 use streammap_ext::StreamMap;
 use tokio::{
     io::{AsyncWriteExt, ReadHalf, WriteHalf},
@@ -235,21 +238,18 @@ impl TcpConnectionStealer {
     /// `client_id` to steal traffic from it.
     #[tracing::instrument(level = "trace", skip(self))]
     async fn port_subscribe(&mut self, client_id: ClientID, port: Port) -> Result<(), AgentError> {
-        // TODO(alex): We only check if this `client_id` is already subscribed to this port, but
-        // other clients might be subscribed to it.
-        let ports = self.port_subscriptions.get_client_topics(client_id);
-
-        if ports.contains(&port) {
-            warn!("Port {port:?} is already subscribed for client {client_id:?}!");
-            Ok(())
-        } else {
-            self.port_subscriptions.subscribe(client_id, port);
-            self.iptables
-                .add_redirect(port, self.stealer.local_addr()?.port())?;
-
-            self.send_message_to_single_client(&client_id, DaemonTcp::Subscribed)
-                .await
-        }
+        let res =
+            if let Some(client_id) = self.port_subscriptions.get_topic_subscribers(port).first() {
+                error!("Port {port:?} is already being stolen by client {client_id:?}!");
+                Err(PortAlreadyStolen(port))
+            } else {
+                self.port_subscriptions.subscribe(client_id, port);
+                self.iptables
+                    .add_redirect(port, self.stealer.local_addr()?.port())?;
+                Ok(port)
+            };
+        self.send_message_to_single_client(&client_id, DaemonTcp::Subscribed(res))
+            .await
     }
 
     /// Helper function to handle [`Command::PortUnsubscribe`] messages.

--- a/mirrord/agent/tests/blackbox.rs
+++ b/mirrord/agent/tests/blackbox.rs
@@ -77,7 +77,7 @@ mod tests {
                 .await
                 .expect("couldn't get next message")
                 .expect("got invalid message"),
-            DaemonMessage::Tcp(DaemonTcp::Subscribed(Ok(subscription_port)))
+            DaemonMessage::Tcp(DaemonTcp::SubscribeResult(Ok(subscription_port)))
         ));
         let mut test_conn = TcpStream::connect("127.0.0.1:1337")
             .await

--- a/mirrord/agent/tests/blackbox.rs
+++ b/mirrord/agent/tests/blackbox.rs
@@ -63,9 +63,12 @@ mod tests {
         });
 
         let mut codec = Framed::new(stream, ClientCodec::new());
+        let subscription_port = 1337;
 
         codec
-            .send(ClientMessage::Tcp(LayerTcp::PortSubscribe(1337)))
+            .send(ClientMessage::Tcp(LayerTcp::PortSubscribe(
+                subscription_port,
+            )))
             .await
             .expect("port subscribe failed");
         assert!(matches!(
@@ -74,7 +77,7 @@ mod tests {
                 .await
                 .expect("couldn't get next message")
                 .expect("got invalid message"),
-            DaemonMessage::Tcp(DaemonTcp::Subscribed)
+            DaemonMessage::Tcp(DaemonTcp::Subscribed(Ok(subscription_port)))
         ));
         let mut test_conn = TcpStream::connect("127.0.0.1:1337")
             .await

--- a/mirrord/layer/src/error.rs
+++ b/mirrord/layer/src/error.rs
@@ -133,6 +133,12 @@ pub(crate) enum LayerError {
 
     #[error("mirrord-layer: Failed to find a process to hook mirrord into!")]
     NoProcessFound,
+
+    #[error("mirrord-layer: Port {0} is already being stolen by another mirrord client!")]
+    PortAlreadyStolen(u16),
+
+    #[error("mirrord-layer: Got unexpected response error from agent: {0}")]
+    UnexpectedResponseError(ResponseError),
 }
 
 // Cannot have a generic From<T> implementation for this error, so explicitly implemented here.
@@ -185,6 +191,11 @@ impl From<HookError> for i64 {
                     mirrord_protocol::ResolveErrorKindInternal::Timeout => libc::EAI_AGAIN,
                     _ => libc::EAI_FAIL,
                 },
+                // for listen, EINVAL means "socket is already connected."
+                // Will not happen, because this ResponseError is not return from any hook, so it
+                // never appears as HookError::ResponseError(PortAlreadyStolen(_)).
+                // this could be changed by waiting for the Subscribed response from agent.
+                ResponseError::PortAlreadyStolen(_port) => libc::EINVAL,
             },
             HookError::DNSNoName => libc::EFAULT,
             HookError::Utf8(_) => libc::EINVAL,

--- a/mirrord/layer/src/tcp.rs
+++ b/mirrord/layer/src/tcp.rs
@@ -83,16 +83,16 @@ pub(crate) trait TcpHandler {
             }
             DaemonTcp::Data(tcp_data) => self.handle_new_data(tcp_data).await,
             DaemonTcp::Close(tcp_close) => self.handle_close(tcp_close),
-            DaemonTcp::Subscribed(Ok(port)) => {
+            DaemonTcp::SubscribeResult(Ok(port)) => {
                 // Added this so tests can know when traffic can be sent
                 debug!("daemon subscribed to port {port}.");
                 Ok(())
             }
-            DaemonTcp::Subscribed(Err(ResponseError::PortAlreadyStolen(port))) => {
+            DaemonTcp::SubscribeResult(Err(ResponseError::PortAlreadyStolen(port))) => {
                 error!("Port subscription failed with for port {port}.");
                 Err(PortAlreadyStolen(port))
             }
-            DaemonTcp::Subscribed(Err(other_error)) => {
+            DaemonTcp::SubscribeResult(Err(other_error)) => {
                 error!("Port subscription failed with unexpected error: {other_error}.");
                 Err(UnexpectedResponseError(other_error))
             }

--- a/mirrord/protocol/src/error.rs
+++ b/mirrord/protocol/src/error.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 use tracing::warn;
 use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
 
+use crate::Port;
+
 #[derive(Encode, Decode, Debug, PartialEq, Clone, Eq, Error)]
 pub enum ResponseError {
     #[error("Index allocator is full, operation `{0}` failed!")]
@@ -30,6 +32,9 @@ pub enum ResponseError {
 
     #[error("Remote operation failed with `{0}`")]
     Remote(#[from] RemoteError),
+
+    #[error("Could not subscribe to port `{0}`, as it is being stolen by another mirrord client.")]
+    PortAlreadyStolen(Port),
 }
 
 #[derive(Encode, Decode, Debug, PartialEq, Clone, Eq, Error)]

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -2,7 +2,7 @@ use std::{fmt, net::IpAddr};
 
 use bincode::{Decode, Encode};
 
-use crate::{ConnectionId, Port};
+use crate::{ConnectionId, Port, RemoteResult};
 
 #[derive(Encode, Decode, Debug, PartialEq, Eq, Clone)]
 pub struct NewTcpConnection {
@@ -48,7 +48,7 @@ pub enum DaemonTcp {
     Close(TcpClose),
     /// Used to notify the subscription occured, needed for e2e tests to remove sleeps and
     /// flakiness.
-    Subscribed,
+    Subscribed(RemoteResult<Port>),
 }
 
 /// Messages related to Steal Tcp handler from client.

--- a/mirrord/protocol/src/tcp.rs
+++ b/mirrord/protocol/src/tcp.rs
@@ -48,7 +48,7 @@ pub enum DaemonTcp {
     Close(TcpClose),
     /// Used to notify the subscription occured, needed for e2e tests to remove sleeps and
     /// flakiness.
-    Subscribed(RemoteResult<Port>),
+    SubscribeResult(RemoteResult<Port>),
 }
 
 /// Messages related to Steal Tcp handler from client.


### PR DESCRIPTION
  Send back the subscribed port in a `RemoteResult` from agent to
  layer. If the layer gets an error on the subscription message,
  it raises an error which stops the layer. The stealer returns an
  error if it receives a subscription request to a port that is
  already being stolen by another client (another layer).
